### PR TITLE
Add a basic test to root command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/virtual-kubelet/virtual-kubelet v1.0.0
 	go.opencensus.io v0.20.2
+	gotest.tools v0.0.0-20181223230014-1083505acf35
 	k8s.io/api v0.0.0-20190222213804-5cb15d344471
 	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/client-go v10.0.0+incompatible

--- a/internal/commands/root/root_test.go
+++ b/internal/commands/root/root_test.go
@@ -1,0 +1,43 @@
+package root
+
+import (
+	"context"
+	"testing"
+
+	"github.com/virtual-kubelet/node-cli/opts"
+	"github.com/virtual-kubelet/node-cli/provider"
+	"github.com/virtual-kubelet/node-cli/provider/mock"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRunRootCommand(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opts := opts.New()
+
+	providerInitFunc := func(cfg provider.InitConfig) (provider.Provider, error) {
+		mockConfig := mock.MockConfig{
+			CPU:    "1",
+			Memory: "128M",
+			Pods:   "120",
+		}
+		return mock.NewMockProviderMockConfig(mockConfig, cfg.NodeName, cfg.OperatingSystem, cfg.InternalIP, cfg.DaemonPort)
+	}
+	fakeClient := fake.NewSimpleClientset()
+	errCh := make(chan error)
+	go func() {
+		errCh <- runRootCommandWithProviderAndClient(ctx, providerInitFunc, fakeClient, opts)
+	}()
+
+	watch, err := fakeClient.CoreV1().Nodes().Watch(metav1.ListOptions{})
+	assert.NilError(t, err)
+	defer watch.Stop()
+	for ev := range watch.ResultChan() {
+		node := ev.Object.(*corev1.Node)
+		t.Logf("Node registered: %+v", node)
+		break
+	}
+}


### PR DESCRIPTION
This adds a basic test which registers the node in a
fake client.