### PR TITLE
Update call to Create()

### DIFF
--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -172,7 +172,7 @@ func runRootCommandWithProviderAndClient(ctx context.Context, pInit provider.Ini
 			log.G(ctx).Debug("node not found")
 			newNode := pNode.DeepCopy()
 			newNode.ResourceVersion = ""
-			_, err = client.CoreV1().Nodes().Create(newNode)
+			_, err = client.CoreV1().Nodes().Create(ctx, newNode, metav1.CreateOptions{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
To conform with Kubernetes 1.18.0+ Signature Create(ctx context.Context, node *v1.Node, opts metav1.CreateOptions) and match the current support in the master branch on virtual-kubelet repo

https://godoc.org/k8s.io/client-go/kubernetes/typed/core/v1#NodeInterface

