### PR TITLE
Add Darwin as valid kubelet OS option

### DIFF
--- a/internal/commands/root/flag.go
+++ b/internal/commands/root/flag.go
@@ -28,7 +28,7 @@ func installFlags(flags *pflag.FlagSet, c *opts.Opts) {
 	flags.StringVar(&c.KubeNamespace, "namespace", c.KubeNamespace, "kubernetes namespace (default is 'all')")
 	flags.StringVar(&c.KubeClusterDomain, "cluster-domain", c.KubeClusterDomain, "kubernetes cluster-domain (default is 'cluster.local')")
 	flags.StringVar(&c.NodeName, "nodename", c.NodeName, "kubernetes node name")
-	flags.StringVar(&c.OperatingSystem, "os", c.OperatingSystem, "Operating System (Linux/Windows)")
+	flags.StringVar(&c.OperatingSystem, "os", c.OperatingSystem, "Operating System (Linux/Windows/Darwin)")
 	flags.StringVar(&c.Provider, "provider", c.Provider, "cloud provider")
 	flags.StringVar(&c.ProviderConfigPath, "provider-config", c.ProviderConfigPath, "cloud provider configuration file")
 	flags.StringVar(&c.MetricsAddr, "metrics-addr", c.MetricsAddr, "address to listen for metrics/stats requests")

--- a/provider/types.go
+++ b/provider/types.go
@@ -5,6 +5,8 @@ const (
 	OperatingSystemLinux = "Linux"
 	// OperatingSystemWindows is the configuration value for defining Windows.
 	OperatingSystemWindows = "Windows"
+	// OperatingSystemDarwin is the configuration value for defining Darwin.
+	OperatingSystemDarwin = "Darwin"
 )
 
 type OperatingSystems map[string]bool
@@ -15,6 +17,7 @@ var (
 	ValidOperatingSystems = OperatingSystems{
 		OperatingSystemLinux:   true,
 		OperatingSystemWindows: true,
+		OperatingSystemDarwin: true,
 	}
 )
 


### PR DESCRIPTION
Allow for setting "Darwin" as the Virtual Kubelet Provider's OS.
