### PR TITLE
add stable os label kubernetes.io/os

### DIFF
--- a/internal/commands/root/node.go
+++ b/internal/commands/root/node.go
@@ -26,7 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const osLabel = "beta.kubernetes.io/os"
+const betaOsLabel = "beta.kubernetes.io/os"
+const stableOsLabel = "kubernetes.io/os"
 
 // NodeFromProvider builds a kubernetes node object from a provider
 // This is a temporary solution until node stuff actually split off from the provider interface itself.
@@ -58,8 +59,11 @@ func NodeFromProvider(ctx context.Context, name string, taint *v1.Taint, p provi
 	}
 
 	p.ConfigureNode(ctx, node)
-	if _, ok := node.ObjectMeta.Labels[osLabel]; !ok {
-		node.ObjectMeta.Labels[osLabel] = strings.ToLower(node.Status.NodeInfo.OperatingSystem)
+	if _, ok := node.ObjectMeta.Labels[betaOsLabel]; !ok {
+		node.ObjectMeta.Labels[betaOsLabel] = strings.ToLower(node.Status.NodeInfo.OperatingSystem)
+	}
+	if _, ok := node.ObjectMeta.Labels[stableOsLabel]; !ok {
+		node.ObjectMeta.Labels[stableOsLabel] = strings.ToLower(node.Status.NodeInfo.OperatingSystem)
 	}
 	return node
 }


### PR DESCRIPTION
### Why this changes?
1. We are going to support Windows container in ACI VK, and allow customer to use node label to select windows virtual node. Giving the [Kubernetes document](https://kubernetes.io/docs/setup/production-environment/windows/user-guide-windows-containers/#:~:text=following%20default%20labels%3A-,kubernetes.io/os,-%3D%20%5Bwindows%7Clinux%5D), the node label "kubernetes.io/os" should be used for selecting window node.
2. Currently the os label in VK is beta.kubernetes.io/os. Kubernetes has started to use new label "kubernetes.io/os" and deprecated the beta one from v1.18

### What is the changes
Add a new OS labels to VK.